### PR TITLE
Check light id ranges properly

### DIFF
--- a/pkg/dasung/dasung.go
+++ b/pkg/dasung/dasung.go
@@ -105,7 +105,7 @@ const (
 
 // SetLightIntensity sets the specified light intensity
 func (d *DasungControl) SetLightIntensity(light LightID, level int) error {
-	if level < 1 || level > 2 {
+	if light < 1 || light > 2 {
 		return errors.New("light id out of range")
 	}
 


### PR DESCRIPTION
In my addition of this feature I made a last minute range check for the light ID passed to the function.

As it turns out I didn't test this addition and the light ID check always fails..

Sorry for the noise :/ 